### PR TITLE
ヘッダーから LINEUPリンクを削除

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -91,9 +91,6 @@ class Header extends Component {
                     <NavbarItem>
                       <Link to="/posts">お知らせ</Link>
                     </NavbarItem>
-                    <NavbarItem>
-                      <Link to="/lineup">LINEUP</Link>
-                    </NavbarItem>
                   </Fragment>
                 )
               }
@@ -109,11 +106,6 @@ class Header extends Component {
                     <BurgerMenuLinkWrapper>
                       <Link to="/posts" onClick={this.closeBurgerMenu}>
                         お知らせ
-                      </Link>
-                    </BurgerMenuLinkWrapper>
-                    <BurgerMenuLinkWrapper>
-                      <Link to="/lineup" onClick={this.closeBurgerMenu}>
-                        LINEUP
                       </Link>
                     </BurgerMenuLinkWrapper>
                   </BurgerMenu>


### PR DESCRIPTION
表題の通りです。ローカル環境でサーバを立ち上げ、PC/スマホともリンクが消えていることを確認しました

## PC
![2018-09-23 12 57 58](https://user-images.githubusercontent.com/10183110/45924050-d3599900-bf30-11e8-93f0-a072f2e0d91d.png)

## スマホ
![2018-09-23 12 58 21](https://user-images.githubusercontent.com/10183110/45924052-deacc480-bf30-11e8-9051-0ca36dbf65ce.png)
